### PR TITLE
Improvements on older devices, visual fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,6 +106,7 @@ async function processManifest(newManifest) {
     let slideLoads = []
     for (slide in newManifest.data) {
         if (await exists(img_path + newManifest.data[slide].hash + ".b64")) {
+            currentlyProcessing--
             console.log(newManifest.data[slide].hash + " already saved")
         } else {
             await slideDownload(newManifest.data[slide], newManifest.address, newManifest.port);

--- a/server-files/README.md
+++ b/server-files/README.md
@@ -12,7 +12,9 @@ this file makes sure the system is up to date and is cloned properly, this then 
 the following should be used to configure a device
 1. Run the following
 ```
-apt install xinit nodejs npm libcursor1 libnss3-dev x11-server-utils libatk-bridge2.0-0 libgtk-3-dev libatspi-dev libcups2 libxss1
+sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+sudo apt -y install xinit nodejs npm libcursor1 libnss3-dev x11-server-utils libatk-bridge2.0-0 libgtk-3-dev libatspi-dev libcups2 libxss1
 ```
 2. in `raspi-config`, display should be forced 1920x1080, and autologin to console should be selected
 3. place `.bash_profile` and `.xinitrc` in the home folder (most likely `/home/pi`), with `+x` permissions (can be set with `chmod +x [filename]`)

--- a/static/index.html
+++ b/static/index.html
@@ -15,14 +15,18 @@ body {
 }
 #warning {
     color: red;
+    position: fixed;
+    left: 0;
+    top: 0;
+    text-align: left;
 }
 </style>
-<span id='warning'>
-    System initializing. If this message is on the screen for more than a few seconds, something is broken.
-</span>
 <div class='wrap'>
 <img id='main'>
 </div>
+<span id='warning'>
+    System initializing. If this message is on the screen for more than a few seconds, something is broken.
+</span>
 <script>
 console.log("Init")
 require('./index.js')

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,15 @@ body {
     top: 0;
     text-align: left;
 }
+.updater {
+    color: white;
+    padding: 5px;
+    background-color: black;
+    margin: 5px;
+    border-radius: 3px;
+    border: 1px solid darkgray;
+    display: inline-block;
+}
 </style>
 <div class='wrap'>
 <img id='main'>

--- a/static/index.js
+++ b/static/index.js
@@ -62,21 +62,22 @@ async function runLoop() {
 async function warningCheck() {
     let warnings = await get('warnings')
     let warner = document.getElementById("warning")
-    warner.innerHTML = ""
+    let addTo = ""
     for (let warning of warnings) {
         switch (warning) {
             case "NOPASSWORD": 
-                warner.innerHTML += "<b>WARNING:</b> The default password is still set, anyone can change device configuration<br>";
+                addTo += "<b>WARNING:</b> The default password is still set, anyone can change device configuration<br>";
                 break;
             case "NOMANIFEST":
-                warner.innerHTML += "<b>WARNING:</b> No manifest is loaded. Please add this device to a server.<br>"
+                addTo += "<b>WARNING:</b> No manifest is loaded. Please add this device to a server.<br>"
                 break;
             case "CPROC":
                 let totals = await get("currentlyProcessing")
-                warner.innerHTML += `<b>WARNING: </b> ${totals[1]-totals[0]} of ${totals[1]} files processed`
+                addTo += `<span color='white' class='updater'>${totals[1]-totals[0]} of ${totals[1]} slides added</span>`
                 break;
         }
     }
+    warner.innerHTML = addTo
 }
 
 async function init() {

--- a/static/index.js
+++ b/static/index.js
@@ -72,7 +72,8 @@ async function warningCheck() {
                 warner.innerHTML += "<b>WARNING:</b> No manifest is loaded. Please add this device to a server.<br>"
                 break;
             case "CPROC":
-                warner.innerHTML += `<b>WARNING: </b> Currently processing ${await get("currentlyProcessing")} files`
+                let totals = await get("currentlyProcessing")
+                warner.innerHTML += `<b>WARNING: </b> ${totals[1]-totals[0]} of ${totals[1]} files processed`
                 break;
         }
     }

--- a/static/index.js
+++ b/static/index.js
@@ -71,8 +71,9 @@ async function warningCheck() {
             case "NOMANIFEST":
                 warner.innerHTML += "<b>WARNING:</b> No manifest is loaded. Please add this device to a server.<br>"
                 break;
-            case "CPROCESSING":
-                warning.innerHTML += `<b>WARNING: </b> Currently processing ${await get("currentlyProcessing")} files`
+            case "CPROC":
+                warner.innerHTML += `<b>WARNING: </b> Currently processing ${await get("currentlyProcessing")} files`
+                break;
         }
     }
 }
@@ -85,13 +86,13 @@ async function init() {
     }
     nonce = manifest.nonce
     manifest = manifest.data
-    warningCheck();
     runLoop();
 }
 
 init();
 
 setInterval(async () => {
+    warningCheck()
     if ((await get("ping", 0)).nonce != nonce) {
         init()
     }


### PR DESCRIPTION
### Added following back end improvements:

- system streams new images instead of storing them in ram for a while, so now devices with less RAM can work properly
- bug fix where manifest is never saved
- warnings update every second instead of only on slide change (allows for upload progress)
- automatic updates to the initialization files

### Added following visual improvements:
- warnings now appear in top left corner
- warnings continue to show when slides are present (warnings are usually security related and should not be hidden)
- adding slides now shows progress counter
- progress counter has nice box instead of looking like a warning